### PR TITLE
Hardcode the path to the go binary

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -58,7 +58,7 @@ func build(goos string, goarch string) error {
 	os.Setenv("CGO_ENABLED", "0")
 
 	cmd := exec.Command(
-		"go",
+		"/usr/local/go/bin/go",
 		"build",
 		"-v",
 		"-o",


### PR DESCRIPTION
The official docker images don't include the path to go in them :(