### PR TITLE
Format errors and sleep in between them

### DIFF
--- a/pratus.go
+++ b/pratus.go
@@ -92,7 +92,8 @@ func main() {
 
 		state, statuses, err := getPRState(owner, repo, number, token)
 		if err != nil {
-			print(err)
+			fmt.Println(err)
+			time.Sleep(sleepTimer)
 			continue
 		}
 


### PR DESCRIPTION
Currently if `pratus` is running and network connectivity is lost it will
spam messages like `(0x136a720,0xc00005ee20)` as fast as possible.
Change to format the error message returned from `getPRState` to see what
the error is and sleep in between to avoid spamming the error.