### PR TITLE
Fix pending state race condition in combined state

### DIFF
--- a/pratus.go
+++ b/pratus.go
@@ -97,7 +97,7 @@ func main() {
 			continue
 		}
 
-		if stillPending(statuses) {
+		if state == "pending" || stillPending(statuses) {
 			fmt.Print(".")
 			time.Sleep(sleepTimer)
 			continue


### PR DESCRIPTION
This fixes the situation where the PR was pending at the start of the
loop but finished before each individual status had been checked.

Closes: #9